### PR TITLE
Tweaks to ensure versioneer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 requirements:
   build:
     - python
-    - setuptools
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,13 +7,12 @@ package:
   version: {{ version }}
 
 source:
-  fn: QCEngine-{{ version }}.tar.gz
-  url: https://github.com/MolSSI/QCEngine/archive/v{{ version }}.tar.gz
+  url: https://github.com/MolSSI/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
 
 requirements:
@@ -31,7 +30,6 @@ requirements:
 
 test:
   imports:
-    - pytest
     - qcengine
   requires:
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "qcengine" %}
 {% set version = "0.5.1" %}
-{% set sha256 = "0d70a463859a5e15c74b1ba32e7d746a5ac59d8c624c9b545ca943fc06214d5e" %}
+{% set sha256 = "c9c2e00683f3086bbb642083d37c68bb220a6fca6d722bb431373a98a824aa5b" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/MolSSI/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
 
 requirements:
   build:


### PR DESCRIPTION
It looks like on the last build, one of the pip lines stopped versioneer from running: `Successfully installed qcengine-0+unknown`. Attempting to fix.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
